### PR TITLE
[ADD]mypage/challenges logic created

### DIFF
--- a/src/app/mypage/challenges/page.tsx
+++ b/src/app/mypage/challenges/page.tsx
@@ -1,8 +1,109 @@
 "use client";
-import React from "react";
+import { supabase } from "@/supabase/supabase";
+import { DateTime } from "luxon";
+import React, { useEffect, useState } from "react";
+
+type Challenge = {
+  id: string;
+  name: string;
+  start_date: string;
+  end_date: string;
+  thumbnail: string;
+};
+
+type UserChallenge = {
+  id: string;
+  challenge_id: string;
+  user_profile_id: string;
+  challenges: Challenge;
+  startDate: number;
+  endDate: number;
+};
 
 const Challenges = () => {
-  return <div>challenges</div>;
+
+  const [challenges, setChallenges] = useState<UserChallenge[]>([]);
+
+  useEffect(() => {
+    const fetchChallenges = async () => {
+      const { data } = await supabase.auth.getSession();
+      const userData = data.session?.user.id;
+
+      if (userData) {
+        const { data, error } = await supabase
+          .from("user_challenges")
+          .select(
+            `
+          id, 
+          challenge_id,
+          user_profile_id,
+          challenges:challenge_id (*)  // challenges 테이블과 조인
+        `
+          )
+          .eq("user_profile_id", userData);
+
+        if (error) {
+          console.error("에러발생함", error);
+          return;
+        }
+        setChallenges(data);
+      }
+    };
+    fetchChallenges();
+  }, []);
+
+  console.log("올바르게 불러와지는 지 체크임", challenges);
+
+  
+
+  return (
+    <div className="min-w-120">
+      <h2 className="flex justify-center">Challenges</h2>
+      <ul className="flex flex-col justify-center items-center gap-8">
+        {challenges.length > 0 ? (
+          challenges.map((item) => {
+            const startDate  = DateTime.fromISO(item.challenges.start_date)
+            const endDate = DateTime.fromISO(item.challenges.end_date)
+
+            const formatStartDate = startDate.toFormat('M월 d일')
+            const formatendtDate = endDate.toFormat('M월 d일')
+
+            const diff = endDate.diff(startDate, ['days'])
+            const diffDays = diff.days
+
+            const weeks = Math.floor(diffDays / 7)
+            const days = diffDays % 7
+
+            let durationMessage = `${diffDays}일`
+
+            if (weeks > 0) {
+              durationMessage = `${weeks}주`
+              if (days > 0) {
+                durationMessage += `${days}일`
+              }
+            }
+
+            return (
+              <div className="flex justify-between gap-8" key={item.challenges.id}>
+                <img
+                  src={`${item.challenges.thumbnail}`}
+                  alt="섬네일 이미지"
+                  width={125}
+                  height={125}
+                />
+                <div>
+                  <p>{item.challenges.name} {durationMessage}</p>
+                  <p>{formatStartDate} ~ {formatendtDate} </p>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <p>도전중인 챌린지가 존재하지 않아요</p>
+        )}
+      </ul>
+    </div>
+  );
 };
 
 export default Challenges;


### PR DESCRIPTION
## 왜 필요한가요?

- 챌린지 페이지에서 user_challenge 테이블을 가져옵니다.
- 가져올 때는 로그인 한 유저의 uid와 일치하는지 여부를 판단하여 가져옵니다.

## 어떤 변화가 생겼나요?

- mypage/challenges 디렉토리에 파일을 생성, 기능을 추가하였습니다.
- luxon 라이브러리를 통해 시간을 계산, 타입문제를 부분적으로 해결하였습니다.
- 추후 타입에 대한 정리나 컴포넌트 분리가 필요합니다.

## 스크린샷

![image](https://github.com/monkeyhurray/Change-Days/assets/109938441/a5b7919b-3120-458d-b906-06d5bbad1e10)

