### PR TITLE
Fix : 메인페이지검색-> 검색페이지 정상출력,

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,26 +1,19 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { supabase } from "@/supabase/supabase";
 import { useInView } from "react-intersection-observer";
 import ChallengeCard from "@/components/searchPage/ChallengeCard";
 import useSearchStore from "@/store/store";
-
+import { ChallengeListRow } from "../page";
 const SearchPage = () => {
   const [searchItem, setSearchItem] = useState("");
   const { ref, inView } = useInView();
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchClicked, setSearchClicked] = useState(false);
   const [debouncedSearchItem, setDebouncedSearchItem] = useState("");
-  const { searchText } = useSearchStore((state) => state);
+  const { searchText, setSearchText } = useSearchStore((state) => state);
   const resetText = useSearchStore((state) => state.resetText);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedSearchItem(searchItem);
-    }, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, [searchItem]);
 
   const {
     data: infiniteData,
@@ -53,13 +46,8 @@ const SearchPage = () => {
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.nextPage,
+    refetchOnWindowFocus: false,
   });
-  console.log("infiniteData", infiniteData);
-  useEffect(() => {
-    if (inView && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, fetchNextPage]);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchItem(event.target.value);
@@ -73,23 +61,51 @@ const SearchPage = () => {
   };
 
   useEffect(() => {
+    if (inView && hasNextPage) {
+      console.log("inView", inView);
+      console.log("hasNextPage", hasNextPage);
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
     resetText();
   }, []);
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchItem(searchItem);
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchItem]);
+
+  useEffect(() => {
+    if (searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (searchText && !searchItem) {
+      setSearchItem(searchText); // searchText 값이 있고 searchItem이 비어있을 때만 넣어줌
+    }
+  }, [searchText, searchItem]);
+
   return (
     <div className="bg-white flex justify-center min-w-full min-h-full py-32">
-      <div>
-        <form className="flex items-center justify-center mb-10">
+      <div className="w-full fix">
+        <form className="flex items-center justify-center mb-10 px-64  ">
           <input
             type="text"
-            placeholder="검색어를 입력하세요"
+            placeholder="검색어를 입력하세요 자동으로 화면에 나타납니다"
             value={searchItem}
-            // value={searchText}
             onChange={handleSearchChange}
-            className="px-4 py-2 mr-2 border border-gray-300 rounded-md focus:outline-none focus:border-blue-500"
+            ref={searchInputRef}
+            className="px-4 py-2 min-w-full mr-2 border border-gray-300 rounded-md focus:outline-none focus:border-blue-500"
           />
         </form>
-        <div className="flex py-14 pt-20 max-h-full ">
-          <div className="flex flex-wrap justify-center  gap-8">
+        <div className="flex pb-14 pt-20 justify-center">
+          <div className="flex flex-wrap justify-center gap-8">
             {infiniteData?.pages.map((page) => page.supabaseData)[0].length !==
             0 ? (
               infiniteData?.pages.map((page) =>
@@ -102,7 +118,7 @@ const SearchPage = () => {
                 ))
               )
             ) : (
-              <h3>검색된 데이터가 없습니다.</h3>
+              <h3>검색하신 데이터가 없습니다</h3>
             )}
           </div>
 

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,78 @@
+// app/page.jsx
+// "use client" 지시어를 사용하여 클라이언트 측에서만 실행되도록 설정
+"use client";
+
+// app/page.tsx
+
+import { useState } from "react";
+import { createClient } from "@supabase/supabase-js";
+import { supabase } from "@/supabase/supabase";
+
+// Supabase 클라이언트 초기화 (이 부분은 실제 환경에 맞게 조정해야 함)
+
+function ImageUploader() {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const uploadImageToChallengeFolder = async (file: File) => {
+    const fileExt = file.name.split(".").pop();
+    const fileName = `${Math.random()}.${fileExt}`; // 고유한 파일명 생성
+
+    const { error: uploadError } = await supabase.storage
+      .from("images")
+      .upload(`challenge/${fileName}`, file);
+
+    if (uploadError) {
+      throw new Error("이미지 업로드 실패: " + uploadError.message);
+    }
+
+    return `${process.env
+      .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/challenge/${fileName}`;
+  };
+
+  const insertThumbnailUrl = async (thumbnailUrl: string) => {
+    const { data, error } = await supabase
+      .from("challenges")
+      .insert([{ thumbnail: thumbnailUrl }]);
+
+    if (error) {
+      throw new Error("데이터베이스 삽입 실패: " + error.message);
+    }
+
+    return data;
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!file) return;
+
+    try {
+      const uploadedImageUrl = await uploadImageToChallengeFolder(file);
+      await insertThumbnailUrl(uploadedImageUrl);
+      alert("이미지가 성공적으로 업로드되었습니다.");
+    } catch (error: any) {
+      alert(error.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="file" onChange={handleFileChange} />
+      <button type="submit">Upload Image</button>
+    </form>
+  );
+}
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Image Upload to Supabase</h1>
+      <ImageUploader />
+    </div>
+  );
+}

--- a/src/components/searchPage/ChallengeCard.tsx
+++ b/src/components/searchPage/ChallengeCard.tsx
@@ -1,52 +1,62 @@
-"use client";
-import Image from "next/image";
+// "use client";
+// import Image from "next/image";
 import { useRouter } from "next/navigation";
-import React, { FC } from "react";
+import React from "react";
 import publicChallengeImage from "../../../public/challenge.jpeg";
+import { ChallengeListRow } from "@/app/page";
+import { timeUtil } from "@/utils/timeutils";
 
 // extends를 해주면 <TodoCard 뒤에 속성들 나타남
-interface ChallengeCardProps
-  extends React.HTMLAttributes<HTMLParagraphElement> {
+// interface ChallengeCardProps
+//   extends React.HTMLAttributes<HTMLParagraphElement> {
+//   challenge: ChallengeListRow;
+//   innerRef?: React.Ref<HTMLParagraphElement>;
+// }
+const ChallengeCard = ({
+  challenge,
+  innerRef,
+}: {
   challenge: any;
-  innerRef?: React.Ref<HTMLParagraphElement>;
-}
-const ChallengeCard: FC<ChallengeCardProps> = ({ challenge, innerRef }) => {
+  innerRef: React.Ref<HTMLParagraphElement>;
+}) => {
   const router = useRouter();
-
+  const { formatStartDate, formatEndDate, formattedCreatedAt } = timeUtil(
+    challenge.start_date,
+    challenge.end_date,
+    challenge.created_at
+  );
   return (
     <div
-      className=" p-14 text-center py-4 text-2xl border-2 flex flex-col cursor-pointer hover:scale-105 w-96 "
+      className="flex p-14 border-2 cursor-pointer hover:scale-105 w-96 hover:bg-slate-200 hover:border-2 hover:border-slate-400"
       key={challenge.id}
       ref={innerRef}
       onClick={() => {
         router.push(`/challenge/${challenge.id}`);
       }}
     >
+      {/* 이미지 데이터를 캐시하는데 부하가 생긱수도있어서 */}
       {/* <img src={publicChallengeImage.src} alt="dd" /> 이미지태그 그냥 public폴더 이미지 쓸때 */}
       {/* <Image src={publicChallengeImage} alt="" /> next/image에서 그냥  public폴더 이미지 쓸때 */}
-
-      <div>
-        {challenge.thumbnail ? (
+      <div className="flex flex-col w-64">
+        <div className="mb-2">
           <img
             src={challenge.thumbnail}
-            alt={challenge.name}
-            className="w-64 h-64 object-cover"
+            alt={`${challenge.name}이미지`}
+            className="w-64 h-64 "
           />
-        ) : (
-          <img
-            src={publicChallengeImage.src}
-            alt="대체 이미지"
-            className="w-64 h-64 object-cover"
-          />
-        )}
-        <section>
-          name:
-          {challenge.name.length > 10
-            ? `${challenge.name.slice(0, 10)}...`
-            : challenge.name}
-        </section>
-        <section>etc:{challenge.etc?.slice(0, 2)}</section>
-        <section>period:{challenge.period}</section>
+        </div>
+        <div>
+          <section className="text-xl font-bold mb-4">
+            {challenge.name.length > 15
+              ? `${challenge.name.slice(0, 15)}...`
+              : challenge.name}
+          </section>
+          <section>설명:{challenge.etc}</section>
+          <section>생성날짜:{formattedCreatedAt}</section>
+          <section>
+            기간:{formatStartDate} ~ {formatEndDate}
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/src/utils/timeutils.ts
+++ b/src/utils/timeutils.ts
@@ -4,16 +4,22 @@ type TimeUtilFormat = {
   formatStartDate: string;
   formatEndDate: string;
   durationMessage: string;
+  formattedCreatedAt: string; // formattedCreatedAt를 반환 형식에 추가
 };
 
-export const timeUtil = (startIso: string, endIso: string): TimeUtilFormat => {
+export const timeUtil = (
+  startIso: string,
+  endIso: string,
+  createdAtIso: string // created_at을 인수로 전달
+): TimeUtilFormat => {
   const startDate = DateTime.fromISO(startIso);
   const endDate = DateTime.fromISO(endIso);
+  const createdAtDate = DateTime.fromISO(createdAtIso); // created_at을 DateTime으로 변환
 
-  const formatStartDate = startDate.toFormat('M월 d일');
-  const formatEndDate = endDate.toFormat('M월 d일'); 
+  const formatStartDate = startDate.toFormat("M월 d일");
+  const formatEndDate = endDate.toFormat("M월 d일");
 
-  const diff = endDate.diff(startDate, ['days']);
+  const diff = endDate.diff(startDate, ["days"]);
   const diffDays = diff.days;
 
   const weeks = Math.floor(diffDays / 7);
@@ -28,5 +34,18 @@ export const timeUtil = (startIso: string, endIso: string): TimeUtilFormat => {
     }
   }
 
-  return { formatStartDate, formatEndDate, durationMessage }; 
+  const formattedCreatedAt = createdAtDate.setLocale("ko").toLocaleString({
+    weekday: "short",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+  return {
+    formatStartDate,
+    formatEndDate,
+    durationMessage,
+    formattedCreatedAt,
+  }; // formattedCreatedAt를 반환 객체에 포함
 };


### PR DESCRIPTION
검색페이지 내 챌린지 개설 목록들의 내용 변경
timeutils 생성 날짜 추가
이미지 thumbnail 관련 테스트 페이지 추가

## 왜 필요한가요?

- 1 기존에는 메인페이지에서 검색을 했을 때 search페이지에서 검색결과+ 전체 데이터를 불러왔습니다.
- 2 

## 어떤 변화가 생겼나요?

- 1 메인페이지에서 검색 했을 때 서치페이지에 검색 결과만 나타납니다.
- 2 서치페이지에서 챌린지 목록들의 내용을 변경했습니다

## 스크린샷
