### PR TITLE
[ADD] created challenge page router and util FC

### DIFF
--- a/src/app/create-challenge/page.tsx
+++ b/src/app/create-challenge/page.tsx
@@ -134,7 +134,7 @@ const CreateChallengePage = () => {
         throw new Error("이미지 업로드 실패", error);
       }
       return `${process.env
-        .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/challenge/${fileName}`;
+        .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/challenge/${fileName}`;
     } catch (error) {
       console.log(error);
     }

--- a/src/app/mypage/challenges/page.tsx
+++ b/src/app/mypage/challenges/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { supabase } from "@/supabase/supabase";
+import { fetchChallenges } from "@/utils/fetchChallenges";
 import { timeUtil } from "@/utils/timeutils";
+import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 
 type Challenge = {
@@ -22,37 +24,26 @@ type UserChallenge = {
 };
 
 const Challenges = () => {
+
+  const router = useRouter()
   const [challenges, setChallenges] = useState<UserChallenge[]>([]);
 
+
   useEffect(() => {
-    const fetchChallenges = async () => {
-      const { data } = await supabase.auth.getSession();
+    supabase.auth.getSession().then(({ data }) => {
       const userId = data.session?.user.id;
-
       if (userId) {
-        const { data, error } = await supabase
-          .from("user_challenges")
-          .select(
-            `
-          id, 
-          challenge_id,
-          user_profile_id,
-          challenges :challenge_id (*)
-        `
-          )
-          .eq("user_profile_id", userId);
-
-        if (error) {
-          console.error("에러발생함", error);
-          return;
-        }
-        setChallenges(data);
+        fetchChallenges(userId, setChallenges);
       }
-    };
-    fetchChallenges();
+    })
   }, []);
 
   console.log("올바르게 불러와지는 지 체크임", challenges);
+
+  const handleGetChallengeButton = (id : string) => {
+    router.push(`/challenge/${id}`)
+  }
+
 
   return (
     <div className="min-w-120">
@@ -65,6 +56,7 @@ const Challenges = () => {
 
             return (
               <div
+                onClick={()=>handleGetChallengeButton(item.challenges.id)}
                 className="flex justify-between gap-8"
                 key={item.challenges.id}
               >

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import UserData, { UserDataProps } from "@/components/mypage/UserData";
+import  { UserDataProps } from "@/components/mypage/UserData";
 import { supabase } from "@/supabase/supabase";
-import { User } from "@supabase/supabase-js";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { FaChevronRight } from "react-icons/fa";
 
@@ -13,7 +11,6 @@ const UserPage = () => {
 
   const fetchUserData = async () => {
     const { data, error } = await supabase.auth.getUser();
-    // console.log("user", data.user);
     if (data.user) {
       console.log("userId", data.user.id);
       const { data: userData, error: userError } = await supabase
@@ -26,9 +23,29 @@ const UserPage = () => {
     }
   };
 
+  const fetchChallenges = async() => {
+    const { data } = await supabase
+      .from("user_challenges")
+      .select(`
+      id,
+      challenge_id,
+      user_profile_id,
+      challenges : challenge_id(*)`)
+      .eq("user_profile_id", user)
+    
+    console.log('challenges', data)
+  }
+
+
+
   useEffect(() => {
     fetchUserData();
+    fetchChallenges()
   }, []);
+
+
+
+
 
   if (user) {
     return (

--- a/src/utils/fetchChallenges.ts
+++ b/src/utils/fetchChallenges.ts
@@ -1,0 +1,35 @@
+import { supabase } from "@/supabase/supabase";
+
+type Challenge = {
+  id: string;
+  name: string;
+  start_date: string;
+  end_date: string;
+  thumbnail: string;
+  createdAt : string
+};
+
+  export const fetchChallenges = async (userId : string, setChallengesCallback :(challenges : Challenge[]) => void) : Promise<void> => {
+    if (!userId) return;
+
+      if (userId) {
+        const { data, error } = await supabase
+          .from("user_challenges")
+          .select(
+            `
+          id, 
+          challenge_id,
+          user_profile_id,
+          challenges :challenge_id (*)
+        `
+          )
+          .eq("user_profile_id", userId);
+
+        if (error) {
+          console.error("에러발생함", error);
+          return;
+        }
+        
+        setChallengesCallback(data);
+      }
+    };


### PR DESCRIPTION
## 왜 필요한가요?

- 중복되는 함수를 정리하였습니다.
- 페이지간의 이동을 구현하였습니다.

## 어떤 변화가 생겼나요?

-  user_challenges데이터를 fetch해오는 함수를 별도의 util함수로 변경했습니다
- mypage/challenges/page.tsx 에 존재하는 챌린지를 클릭 시, challenge/[id]/page.tsx로 이동하는 로직을 구현하였습니다.

## 스크린샷


